### PR TITLE
add notebook that tests port control

### DIFF
--- a/notebooks/aws.ipynb
+++ b/notebooks/aws.ipynb
@@ -206,10 +206,7 @@
     }
    ],
    "source": [
-    "model = DaskLGBMRegressor(\n",
-    "    num_iterations=10,\n",
-    "    num_leaves=10\n",
-    ")\n",
+    "model = DaskLGBMRegressor(num_iterations=10, num_leaves=10)\n",
     "model.fit(data, labels)"
    ]
   },
@@ -247,11 +244,7 @@
     }
    ],
    "source": [
-    "model = DaskLGBMRegressor(\n",
-    "    num_iterations=10,\n",
-    "    num_leaves=10,\n",
-    "    local_listen_port=16000\n",
-    ")\n",
+    "model = DaskLGBMRegressor(num_iterations=10, num_leaves=10, local_listen_port=16000)\n",
     "model.fit(data, labels)"
    ]
   },
@@ -281,18 +274,22 @@
     "import socket\n",
     "from urllib.parse import urlparse\n",
     "\n",
+    "\n",
     "def _find_random_open_port() -> int:\n",
     "    \"\"\"Find a random open port on localhost\"\"\"\n",
     "    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:\n",
-    "        s.bind(('', 0))\n",
+    "        s.bind((\"\", 0))\n",
     "        port = s.getsockname()[1]\n",
     "    return port\n",
     "\n",
+    "\n",
     "worker_addresses = client.scheduler_info()[\"workers\"].keys()\n",
-    "machines=\",\".join([\n",
-    "    urlparse(worker_address).hostname + \":\" + str(_find_random_open_port())\n",
-    "    for worker_address in worker_addresses\n",
-    "])\n",
+    "machines = \",\".join(\n",
+    "    [\n",
+    "        urlparse(worker_address).hostname + \":\" + str(_find_random_open_port())\n",
+    "        for worker_address in worker_addresses\n",
+    "    ]\n",
+    ")\n",
     "print(machines)"
    ]
   },
@@ -321,9 +318,7 @@
     }
    ],
    "source": [
-    "model = DaskLGBMRegressor(\n",
-    "    machines=machines\n",
-    ")\n",
+    "model = DaskLGBMRegressor(machines=machines)\n",
     "model.fit(data, labels)"
    ]
   }

--- a/notebooks/aws.ipynb
+++ b/notebooks/aws.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "It uses `FargateCluster` from [`dask-cloudprovider`](https://github.com/dask/dask-cloudprovider) to create a distributed cluster.\n",
     "\n",
-    "This notebook was created to test https://github.com/microsoft/LightGBM/pull/3766, a fix for https://github.com/microsoft/LightGBM/issues/3753."
+    "This notebook was most recently updated to test https://github.com/microsoft/LightGBM/pull/3994."
    ]
   },
   {
@@ -29,7 +29,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "scheduler and worker image: public.ecr.aws/m0z8a6o8/dask-lgb-test-4468592b-5204-4e3b-ad80-7c5ae698472a-cluster:1\n"
+      "scheduler and worker image: public.ecr.aws/w8s1c8b1/dask-lgb-test-4468592b-5204-4e3b-ad80-7c5ae698472a-cluster:1\n"
      ]
     }
    ],
@@ -79,16 +79,16 @@
      "text": [
       "/opt/conda/lib/python3.8/contextlib.py:120: UserWarning: Creating your cluster is taking a surprisingly long time. This is likely due to pending resources on AWS. Hang tight! \n",
       "  next(self.gen)\n",
-      "/opt/conda/lib/python3.8/site-packages/distributed/client.py:1128: VersionMismatchWarning: Mismatched versions found\n",
+      "/opt/conda/lib/python3.8/site-packages/distributed/client.py:1135: VersionMismatchWarning: Mismatched versions found\n",
       "\n",
       "+---------+---------------+---------------+---------------+\n",
       "| Package | client        | scheduler     | workers       |\n",
       "+---------+---------------+---------------+---------------+\n",
-      "| blosc   | 1.10.1        | 1.9.2         | 1.9.2         |\n",
+      "| blosc   | 1.10.2        | 1.9.2         | 1.9.2         |\n",
+      "| lz4     | 3.1.3         | 3.1.1         | 3.1.1         |\n",
       "| msgpack | 1.0.2         | 1.0.0         | 1.0.0         |\n",
-      "| numpy   | 1.19.5        | 1.18.5        | 1.18.5        |\n",
-      "| python  | 3.8.5.final.0 | 3.8.0.final.0 | 3.8.0.final.0 |\n",
-      "| tornado | 6.0.4         | 6.1           | 6.1           |\n",
+      "| numpy   | 1.20.1        | 1.18.1        | 1.18.1        |\n",
+      "| python  | 3.8.6.final.0 | 3.8.0.final.0 | 3.8.0.final.0 |\n",
       "+---------+---------------+---------------+---------------+\n",
       "Notes: \n",
       "-  msgpack: Variation is ok, as long as everything is above 0.6\n",
@@ -123,7 +123,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "View the dashboard: http://54.218.161.144:8787/status\n"
+      "View the dashboard: http://54.186.105.162:8787/status\n"
      ]
     }
    ],
@@ -149,120 +149,182 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
     "import dask.array as da\n",
     "from dask.distributed import wait\n",
-    "from lightgbm.dask import DaskLGBMRegressor"
+    "from lightgbm.dask import DaskLGBMRegressor\n",
+    "\n",
+    "num_rows = 1e6\n",
+    "num_features = 1e2\n",
+    "num_partitions = 10\n",
+    "rows_per_chunk = num_rows / num_partitions\n",
+    "\n",
+    "data = da.random.random((num_rows, num_features), (rows_per_chunk, num_features))\n",
+    "\n",
+    "labels = da.random.random((num_rows, 1), (rows_per_chunk, 1))\n",
+    "\n",
+    "data = data.persist()\n",
+    "labels = labels.persist()\n",
+    "_ = wait(data)\n",
+    "_ = wait(labels)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## method 1 - just defaults\n",
+    "\n",
+    "You should be able to connect without specifying any IP addresses or ports."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "attempt 0\n",
-      "attempt 1\n",
-      "attempt 2\n",
-      "attempt 3\n",
-      "attempt 4\n",
-      "attempt 5\n",
-      "attempt 6\n",
-      "attempt 7\n",
-      "attempt 8\n",
-      "attempt 9\n"
+      "Finding random open ports for workers\n"
      ]
     },
     {
-     "name": "stderr",
+     "data": {
+      "text/plain": [
+       "DaskLGBMRegressor(num_iterations=10, num_leaves=10, num_threads=1, time_out=120,\n",
+       "                  tree_learner='data')"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model = DaskLGBMRegressor(\n",
+    "    num_iterations=10,\n",
+    "    num_leaves=10\n",
+    ")\n",
+    "model.fit(data, labels)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## method 2 - local_listen_port\n",
+    "\n",
+    "If you just pass `local_listen_port`, that should be fine."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
      "output_type": "stream",
      "text": [
-      "distributed.client - ERROR - Failed to reconnect to scheduler after 10.00 seconds, closing client\n",
-      "_GatheringFuture exception was never retrieved\n",
-      "future: <_GatheringFuture finished exception=CancelledError()>\n",
-      "asyncio.exceptions.CancelledError\n"
+      "Using passed-in 'local_listen_port' for all workers\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "DaskLGBMRegressor(num_iterations=10, num_leaves=10, num_threads=1, time_out=120,\n",
+       "                  tree_learner='data')"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model = DaskLGBMRegressor(\n",
+    "    num_iterations=10,\n",
+    "    num_leaves=10,\n",
+    "    local_listen_port=16000\n",
+    ")\n",
+    "model.fit(data, labels)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## method 3 - local_listen_port\n",
+    "\n",
+    "You should be able to pass ``machines`` directly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "172.31.4.109:34617,172.31.42.101:47359,172.31.55.201:36471\n"
      ]
     }
    ],
    "source": [
-    "for i in range(10):\n",
-    "    print(f\"attempt {i}\")\n",
+    "import socket\n",
+    "from urllib.parse import urlparse\n",
     "\n",
-    "    client.restart()\n",
+    "def _find_random_open_port() -> int:\n",
+    "    \"\"\"Find a random open port on localhost\"\"\"\n",
+    "    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:\n",
+    "        s.bind(('', 0))\n",
+    "        port = s.getsockname()[1]\n",
+    "    return port\n",
     "\n",
-    "    num_rows = 1e6\n",
-    "    num_features = 1e2\n",
-    "    num_partitions = 10\n",
-    "    rows_per_chunk = num_rows / num_partitions\n",
-    "\n",
-    "    data = da.random.random((num_rows, num_features), (rows_per_chunk, num_features))\n",
-    "\n",
-    "    labels = da.random.random((num_rows, 1), (rows_per_chunk, 1))\n",
-    "\n",
-    "    data = data.persist()\n",
-    "    labels = labels.persist()\n",
-    "    _ = wait(data)\n",
-    "    _ = wait(labels)\n",
-    "\n",
-    "    dask_reg = DaskLGBMRegressor(\n",
-    "        silent=False,\n",
-    "        max_depth=5,\n",
-    "        random_state=708,\n",
-    "        objective=\"regression_l2\",\n",
-    "        learning_rate=0.1,\n",
-    "        tree_learner=\"data\",\n",
-    "        n_estimators=10,\n",
-    "        min_child_samples=1,\n",
-    "        n_jobs=-1,\n",
-    "        local_listen_port=12400,\n",
-    "    )\n",
-    "\n",
-    "    dask_reg.fit(\n",
-    "        client=client,\n",
-    "        X=data,\n",
-    "        y=labels,\n",
-    "    )"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The model produced by this training run is an instance of `DaskLGBMRegressor`. To get a regular non-Dask model (which can be pickled and saved), run `.to_local()`."
+    "worker_addresses = client.scheduler_info()[\"workers\"].keys()\n",
+    "machines=\",\".join([\n",
+    "    urlparse(worker_address).hostname + \":\" + str(_find_random_open_port())\n",
+    "    for worker_address in worker_addresses\n",
+    "])\n",
+    "print(machines)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Using passed-in 'machines' parameter\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "DaskLGBMRegressor(num_iterations=10, num_leaves=10, num_threads=1, time_out=120,\n",
+       "                  tree_learner='data')"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "local_model = dask_reg.to_local()\n",
-    "type(local_model)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "You can visualize this model by looking at a data frame representation of it. You can also check that the model really used inputs from all workers."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "dask_reg.booster_.trees_to_dataframe().iloc[\n",
-    "    0,\n",
-    "][\"count\"] == 1e6"
+    "model = DaskLGBMRegressor(\n",
+    "    machines=machines\n",
+    ")\n",
+    "model.fit(data, labels)"
    ]
   }
  ],
@@ -282,7 +344,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Adds a notebook that tests https://github.com/microsoft/LightGBM/pull/3994. That PR proposes tighter control over the ports used by `lightgbm.dask`.