### PR TITLE
add CI status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Testing `lightgbm.dask`
 
+[![GitHub Actions status](https://github.com/jameslamb/lightgbm-dask-testing/workflows/Continuous%20Integration/badge.svg?branch=main)](https://github.com/jameslamb/lightgbm-dask-testing/actions)
+
 This repository can be used to test and develop changes to LightGBM's Dask integration. It contains the following useful features:
 
 * `make` recipes for building a local development image with `lightgbm` installed from a local copy, and Jupyter Lab running for interactive development


### PR DESCRIPTION
Adds a badge with the status of this repo's GitHub Actions builds.

![image](https://user-images.githubusercontent.com/7608904/111937471-cda78480-8a95-11eb-859a-cb8ea6be4b89.png)
