### PR TITLE
add rounding on log message

### DIFF
--- a/notebooks/demo-aws.ipynb
+++ b/notebooks/demo-aws.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "classified-celtic",
+   "id": "tribal-xerox",
    "metadata": {},
    "source": [
     "# LightGBM + Dask\n",
@@ -28,7 +28,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "photographic-little",
+   "id": "amino-hunger",
    "metadata": {},
    "source": [
     "<hr>\n",
@@ -41,7 +41,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "adjacent-candidate",
+   "id": "expanded-declaration",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -56,7 +56,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "chicken-handle",
+   "id": "harmful-bosnia",
    "metadata": {},
    "source": [
     "Before proceeding, set up your AWS credentials. If you're unsure how to do this, see [the AWS docs](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html)."
@@ -65,7 +65,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "prepared-reggae",
+   "id": "sufficient-evanescence",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -76,7 +76,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cardiovascular-school",
+   "id": "complicated-little",
    "metadata": {},
    "source": [
     "Create a cluster with 3 workers. See https://cloudprovider.dask.org/en/latest/aws.html#dask_cloudprovider.aws.FargateCluster for more options."
@@ -85,7 +85,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "later-cooling",
+   "id": "respective-collect",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -109,7 +109,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "southwest-conflict",
+   "id": "raising-mauritius",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -118,7 +118,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "breeding-ireland",
+   "id": "radical-composition",
    "metadata": {},
    "source": [
     "Click the link above to view a diagnostic dashboard while you run the training code below."
@@ -126,7 +126,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "sublime-estate",
+   "id": "modified-lincoln",
    "metadata": {},
    "source": [
     "<hr>\n",
@@ -141,7 +141,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "parliamentary-constant",
+   "id": "structural-street",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -155,7 +155,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dangerous-palestine",
+   "id": "unavailable-future",
    "metadata": {},
    "source": [
     "Right now, the Dask Arrays `data` and `labels` are lazy. Before training, you can force the cluster to compute them by running `.persist()` and then wait for that computation to finish by `wait()`-ing on them.\n",
@@ -166,7 +166,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "distinct-wireless",
+   "id": "quiet-nicaragua",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -179,7 +179,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "african-leone",
+   "id": "acoustic-corner",
    "metadata": {},
    "source": [
     "<hr>\n",
@@ -192,7 +192,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "billion-migration",
+   "id": "pleased-brunei",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -216,7 +216,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "starting-princess",
+   "id": "designed-kidney",
    "metadata": {},
    "source": [
     "<hr>\n",
@@ -229,7 +229,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "widespread-recruitment",
+   "id": "flexible-constitutional",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -239,7 +239,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "informed-dairy",
+   "id": "funny-trademark",
    "metadata": {},
    "source": [
     "Before calculating the mean absolute error (MAE) of these predictions, compute some summary statistics on the target variable. This is necessary to understand what \"good\" values of MAE look like."
@@ -248,7 +248,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "charming-specific",
+   "id": "cross-mistake",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -256,12 +256,12 @@
     "dy_percentiles = da.percentile(dy, p).compute()\n",
     "\n",
     "for i, percentile in enumerate(p):\n",
-    "    print(f\"{percentile * 100}%: {dy_percentiles[i]}\")"
+    "    print(f\"{percentile * 100}%: {round(dy_percentiles[i], 2)}\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "elegant-donna",
+   "id": "offensive-switch",
    "metadata": {},
    "source": [
     "The metrics functions from `dask-ml` match those from `scikit-learn`, but take in and return Dask collections. You can use these functions to perform model evaluation without the evaluation data or predictions needing to be pulled down to the machine running this notebook. Pretty cool, right?"
@@ -270,7 +270,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "associate-attachment",
+   "id": "hybrid-greece",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -281,7 +281,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "senior-institution",
+   "id": "outer-region",
    "metadata": {},
    "source": [
     "## Next Steps\n",

--- a/notebooks/demo.ipynb
+++ b/notebooks/demo.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "executive-giant",
+   "id": "noticed-account",
    "metadata": {},
    "source": [
     "# LightGBM + Dask\n",
@@ -25,7 +25,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "freelance-force",
+   "id": "surprising-incentive",
    "metadata": {},
    "source": [
     "<hr>\n",
@@ -38,7 +38,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "serious-dispute",
+   "id": "dietary-multimedia",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -55,7 +55,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "according-battlefield",
+   "id": "coated-paper",
    "metadata": {},
    "source": [
     "Click the link above to view a diagnostic dashboard while you run the training code below."
@@ -63,7 +63,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "joined-classics",
+   "id": "confirmed-recommendation",
    "metadata": {},
    "source": [
     "<hr>\n",
@@ -78,7 +78,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "golden-cookbook",
+   "id": "billion-password",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -92,7 +92,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "acknowledged-publicity",
+   "id": "temporal-terrace",
    "metadata": {},
    "source": [
     "Right now, the Dask Arrays `data` and `labels` are lazy. Before training, you can force the cluster to compute them by running `.persist()` and then wait for that computation to finish by `wait()`-ing on them.\n",
@@ -103,7 +103,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "champion-stake",
+   "id": "metallic-attachment",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -116,7 +116,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "considered-savage",
+   "id": "interpreted-central",
    "metadata": {},
    "source": [
     "<hr>\n",
@@ -129,7 +129,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "previous-emphasis",
+   "id": "animated-magnitude",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -141,7 +141,7 @@
     "    objective=\"regression_l1\",\n",
     "    learning_rate=0.1,\n",
     "    tree_learner=\"data\",\n",
-    "    n_estimators=10,\n",
+    "    n_estimators=100,\n",
     "    min_child_samples=1,\n",
     ")\n",
     "\n",
@@ -153,7 +153,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "institutional-airfare",
+   "id": "processed-karen",
    "metadata": {},
    "source": [
     "<hr>\n",
@@ -166,7 +166,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "external-pathology",
+   "id": "logical-handbook",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -176,7 +176,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "coral-barrel",
+   "id": "prerequisite-symposium",
    "metadata": {},
    "source": [
     "Before calculating the mean absolute error (MAE) of these predictions, compute some summary statistics on the target variable. This is necessary to understand what \"good\" values of MAE look like."
@@ -185,7 +185,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "naval-technician",
+   "id": "peaceful-damages",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -193,12 +193,12 @@
     "dy_percentiles = da.percentile(dy, p).compute()\n",
     "\n",
     "for i, percentile in enumerate(p):\n",
-    "    print(f\"{percentile * 100}%: {dy_percentiles[i]}\")"
+    "    print(f\"{percentile * 100}%: {round(dy_percentiles[i], 2)}\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "endless-assets",
+   "id": "romantic-clone",
    "metadata": {},
    "source": [
     "The metrics functions from `dask-ml` match those from `scikit-learn`, but take in and return Dask collections. You can use these functions to perform model evaluation without the evaluation data or predictions needing to be pulled down to the machine running this notebook. Pretty cool, right?"
@@ -207,7 +207,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "tribal-algeria",
+   "id": "considered-holocaust",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -218,7 +218,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "english-fifth",
+   "id": "reduced-teddy",
    "metadata": {},
    "source": [
     "<hr>\n",


### PR DESCRIPTION
adds rounding on two log messages. All the other lines in the diff are because `nbformat` recently added "cell IDs" to Jupyter notebooks, but Jupyter Lab regenerates all of them every time you save a notebook.