### PR TITLE
[ci] ignore LightGBM subdirectory in linting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,8 @@ exclude = '''
   | LightGBM
 )/
 '''
+
+[tool.nbqa.exclude]
+black = "LightGBM/"
+flake8 = "LightGBM/"
+isort = "LightGBM/"

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,3 +10,7 @@ ignore =
     E722,
     # do not assign a lambda expression
     E731
+
+[tool:isort]
+skip_glob=*/LightGBM/*
+


### PR DESCRIPTION
Use of the project involves cloning `LightGBM` into a directory `./LightGBM`. Once you've done this, `make lint` and `make format` (intended only for use on this project's code) will start to complain about code from `./LightGBM`.

This PR proposes ignoring `./LightGBM` in those checks.