### PR TITLE
[ci] lint dockerfiles with hadolint

### DIFF
--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,5 @@
+ignored:
+  - DL3003  # use WORKDIR instead of cd
+  - DL3007  # do not use latest
+  - DL3008  # pin versions in apt
+  - DL3013  # pin versions in pip

--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -14,5 +14,5 @@ RUN apt-get update && \
         dask-ml \
         numpy \
         pandas && \
-        pip install --no-cache-dir \
-            awscli
+    pip install --no-cache-dir \
+        awscli

--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -1,17 +1,18 @@
 FROM daskdev/dask-notebook:latest
 
-RUN apt update && \
+RUN apt-get update && \
     apt-get install -y \
+        --no-install-recommends \
         build-essential \
         cmake \
         lsof \
-        net-tools
-
-RUN conda install -y -c conda-forge \
-    dask-cloudprovider \
-    scikit-learn \
-    dask-ml \
-    numpy \
-    pandas && \
-    pip install \
-        awscli
+        net-tools && \
+    rm -rf /var/lib/apt/lists/* && \
+    conda install -y -c conda-forge \
+        dask-cloudprovider \
+        scikit-learn \
+        dask-ml \
+        numpy \
+        pandas && \
+        pip install --no-cache-dir \
+            awscli

--- a/Dockerfile-cluster
+++ b/Dockerfile-cluster
@@ -1,23 +1,22 @@
 FROM daskdev/dask:latest
 
-RUN apt update && \
-    apt-get install -y \
-        build-essential \
-        cmake
-
 COPY ./LightGBM /opt/LightGBM
 
-RUN conda install -y -c conda-forge \
-    dask-cloudprovider \
-    dask-ml \
-    scikit-learn \
-    numpy \
-    pandas && \
-    pip install \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        cmake && \
+    rm -rf /var/lib/apt/lists/ && \
+    conda install -y -c conda-forge \
+        dask-cloudprovider \
+        dask-ml \
+        scikit-learn \
+        numpy \
+        pandas && \
+    pip install --no-cache-dir \
         awscli && \
     # install LightGBM
     cd /opt/LightGBM/python-package && \
     python setup.py install && \
-    cd /opt && \
     rm -rf /opt/LightGBM && \
     conda clean --all

--- a/Dockerfile-notebook
+++ b/Dockerfile-notebook
@@ -1,4 +1,6 @@
 ARG BASE_IMAGE
+
+# hadolint ignore=DL3006
 FROM ${BASE_IMAGE}
 
 COPY . /home/jovyan/testing

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ format:
 	nbqa black . --nbqa-mutate
 
 .PHONY: lint
-lint:
+lint: lint-dockerfiles
 	isort --check .
 	black --check --diff .
 	diff_lines=$$(nbqa black --nbqa-diff . | wc -l); \
@@ -81,3 +81,15 @@ lint:
 	flake8 --count .
 	nbqa flake8 .
 	nbqa isort --check .
+
+.PHONY: lint-dockerfiles
+lint-dockerfiles:
+	for dockerfile in $$(ls | grep -E '^Dockerfile'); do \
+		echo "linting $${dockerfile}" && \
+		docker run \
+			--rm \
+			-v $$(pwd)/.hadolint.yaml:/.config/hadolint.yaml \
+			-i \
+			hadolint/hadolint \
+		< $${dockerfile} || exit 1; \
+	done


### PR DESCRIPTION
This proposes adding linting on the project's Dockerfiles with https://github.com/hadolint/hadolint.

It also addresses the following warnings thrown by `hadolint`:

```text
# linting on Dockerfile-base
-:1 DL3007 warning: Using latest is prone to errors if the image will ever update. Pin the version explicitly to a release tag
-:3 DL3008 warning: Pin versions in apt get install. Instead of `apt-get install <package>` use `apt-get install <package>=<version>`
-:3 DL3027 warning: Do not use apt as it is meant to be a end-user tool, use apt-get or apt-cache instead
-:3 DL3015 info: Avoid additional packages by specifying `--no-install-recommends`
-:10 DL3059 info: Multiple consecutive `RUN` instructions. Consider consolidation.
-:10 DL3013 warning: Pin versions in pip. Instead of `pip install <package>` use `pip install <package>==<version>` or `pip install --requirement <requirements file>`
-:10 DL3042 warning: Avoid use of cache directory with pip. Use `pip install --no-cache-dir <package>`

# Dockerfile-cluster

-:3 DL3015 info: Avoid additional packages by specifying `--no-install-recommends`
-:3 DL3027 warning: Do not use apt as it is meant to be a end-user tool, use apt-get or apt-cache instead
-:10 DL3003 warning: Use WORKDIR to switch to a directory
-:10 DL3042 warning: Avoid use of cache directory with pip. Use `pip install --no-cache-dir <package>`
```

I'm proposing ignoring some of the warnings that are like "you should pin to a specific version"  because this project is intended for bleeding-edge development, not reproducible research or app development.
