### PR TITLE
fix network setup in ranker notebook

### DIFF
--- a/notebooks/testing/ranker-local.ipynb
+++ b/notebooks/testing/ranker-local.ipynb
@@ -176,11 +176,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "listen_port = 12410\n",
-    "\n",
-    "dask_ranker = DaskLGBMRanker(\n",
-    "    time_out=5, local_listen_port=listen_port, seed=42, min_child_samples=1\n",
-    ")\n",
+    "dask_ranker = DaskLGBMRanker(time_out=5, seed=42, min_child_samples=1)\n",
     "\n",
     "dask_ranker = dask_ranker.fit(X=dX, y=dy, sample_weight=dw, group=dg)\n",
     "rnkvec_dask = dask_ranker.predict(dX)\n",
@@ -230,13 +226,6 @@
     "print(np.abs(dcor - lcor))\n",
     "assert np.abs(dcor - lcor) < 0.003"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Fixes the following error in the ranker testing notebook:

> LightGBMError: 'local_listen_port' was provided in Dask training parameters, but at least one machine in the cluster has multiple Dask worker processes running on it. Please omit 'local_listen_port' or pass 'machines'.

That error is thrown if you specify `local_listen_port` when using `LocalCluster` with multiple workers. See https://lightgbm.readthedocs.io/en/latest/Parallel-Learning-Guide.html#using-specific-ports for more.