### PR TITLE
make sure notebook container is removed when stopped

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ push-image: create-repo
 .PHONY: start-notebook
 start-notebook:
 	docker run \
+		--rm \
 		-v $$(pwd):/home/jovyan/testing \
 		--env AWS_SECRET_ACCESS_KEY=$${AWS_SECRET_ACCESS_KEY:-notset} \
 		--env AWS_ACCESS_KEY_ID=$${AWS_ACCESS_KEY_ID:-notset} \


### PR DESCRIPTION
Proposes running notebook containers with `docker run --rm`, so the containers are automatically removed when the notebook is spun down.

You can confirm that this is working by running the following.

```shell
make notebook-image start-notebook
make stop-notebook
docker container ls
```

No new containers should be returned by `docker container ls`.

### How this improves `lightgbm-dask-testing`

Prevents accumulation of containers from repeated runs of `make start-notebook`, which:

* slightly reduces docker's resource utilization
* prevents cluttered output of `docker container ls`
* makes it possible to remove images without needing to remove old containers