### PR TITLE
remove LightGBM in 'make clean'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ base-image:
 .PHONY: clean
 clean:
 	git clean -d -f -X
+	rm -rf ./LightGBM/
 
 LightGBM/README.md:
 	git clone --recursive https://github.com/microsoft/LightGBM.git


### PR DESCRIPTION
`make clean` should also remove the cloned copy of LightGBM, so other commands refresh it. This PR does that.