### PR TITLE
pin notebook image to 2021.9.1

### DIFF
--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -1,4 +1,7 @@
-FROM daskdev/dask-notebook:latest
+FROM daskdev/dask-notebook:2021.9.1
+
+ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
+ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
     apt-get install -y \


### PR DESCRIPTION
similar to #24, this proposes pinning the notebook image to dask 2021.9.1, to reduce the risk of upstream changes breaking things.

**image sizes**

base: 2GB
notebook: 2.32GB