### PR TITLE
get boto3 from conda-forge and clean cache

### DIFF
--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -7,15 +7,15 @@ RUN apt-get update && \
     apt-get install -y \
         --no-install-recommends \
         build-essential \
-        cmake \
-        lsof \
-        net-tools && \
+        cmake && \
     rm -rf /var/lib/apt/lists/* && \
-    conda install -y -c conda-forge \
-        dask-cloudprovider \
-        scikit-learn \
-        dask-ml \
-        numpy \
-        pandas && \
-    pip install --no-cache-dir \
-        awscli
+    conda install -y \
+        -c conda-forge \
+        --override-channels \
+            boto3 \
+            dask-cloudprovider \
+            scikit-learn \
+            dask-ml \
+            numpy \
+            pandas && \
+    conda clean --yes --all

--- a/Dockerfile-cluster
+++ b/Dockerfile-cluster
@@ -22,4 +22,4 @@ RUN apt-get update && \
     python setup.py install && \
     cd /opt && \
     rm -rf /opt/LightGBM && \
-    conda clean --all
+    conda clean --yes --all


### PR DESCRIPTION
Contributes to #14.

Changes to base image:

* install `boto3` instead of `awscli` (since the base image just needs boto3)
* get `boto3` from `conda-forge` instead of PyPI (to reduce the risk of a broken conda env)
* remove installs of `lsof` and `net-tools` (these were leftover from some old debugging)
* add `conda clean` to clean the conda cache after building
* use `--override-channels` in `conda install` (to reduce environment solve times)

**image sizes**

base: 2GB --> 1.73GB
notebook: 2.32GB --> 2.05GB