### PR TITLE
[notebook-image] remove LightGBM source after compilation

### DIFF
--- a/Dockerfile-notebook
+++ b/Dockerfile-notebook
@@ -6,6 +6,8 @@ FROM ${BASE_IMAGE}
 COPY . /home/jovyan/testing
 
 RUN cd /home/jovyan/testing/LightGBM/python-package && \
-    python setup.py install
+    python setup.py install && \
+    cd /home/jovyan && \
+    rm -rf /home/jovyan/testing/LightGBM
 
 WORKDIR /home/jovyan/testing/notebooks


### PR DESCRIPTION
Contributes to #14.

After installing LightGBM with `python setup.py install`, it's no longer necessary to keep LightGBM source files or intermediate build outputs around.

This PR proposes removing those unnecessary files after compilation.

**image sizes**

base: 1.73GB (no change)
notebook: 2.05GB --> 1.98GB