### PR TITLE
[cluster-image] prefer boto3 to awscli

### DIFF
--- a/Dockerfile-cluster
+++ b/Dockerfile-cluster
@@ -9,14 +9,15 @@ RUN apt-get update && \
         build-essential \
         cmake && \
     rm -rf /var/lib/apt/lists/ && \
-    conda install -y -c conda-forge \
-        dask-cloudprovider \
-        dask-ml \
-        scikit-learn \
-        numpy \
-        pandas && \
-    pip install --no-cache-dir \
-        awscli && \
+    conda install -y \
+        -c conda-forge \
+        --override-channels \
+            boto3 \
+            dask-cloudprovider \
+            dask-ml \
+            numpy \
+            pandas \
+            scikit-learn && \
     # install LightGBM
     cd /opt/LightGBM/python-package && \
     python setup.py install && \


### PR DESCRIPTION
Contributes to #14

Proposes installing `boto3` instead of `awscli` for the cluster image. AWS CLI commands aren't used in the cluster image or its dependencies, so it's enough to just have `boto3`.

This also proposes getting `boto3` from `conda-forge` instead of PyPI, to reduce the risk of breaking the image's conda env.

**images sizes**

cluster: 1.7GB --> 1.69GB