### PR TITLE
[cluster-image] remove cmake and build-essential

### DIFF
--- a/Dockerfile-cluster
+++ b/Dockerfile-cluster
@@ -23,4 +23,7 @@ RUN apt-get update && \
     python setup.py install && \
     cd /opt && \
     rm -rf /opt/LightGBM && \
-    conda clean --yes --all
+    conda clean --yes --all && \
+    apt-get remove -y --purge \
+        build-essential \
+        cmake


### PR DESCRIPTION
Contributes to #14.

`cmake` and a C++ compiler (provided by `build-essential`) are necessary to build LightGBM from source, but not needed in normal operation of a Dask cluster running worker / scheduler processes in containers using the `cluster-image` image.

This PR proposes removing `build-essential` and `cmake` from the cluster image, to reduce its size.

**image sizes**

cluster: 1.69GB --> 1.67GB