### PR TITLE
[cluster-image] switch base to python-slim

### DIFF
--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -7,7 +7,8 @@ RUN apt-get update && \
     apt-get install -y \
         --no-install-recommends \
         build-essential \
-        cmake && \
+        cmake \
+        libomp-dev && \
     rm -rf /var/lib/apt/lists/* && \
     conda install -y \
         -c conda-forge \

--- a/Dockerfile-cluster
+++ b/Dockerfile-cluster
@@ -1,29 +1,34 @@
-FROM daskdev/dask:2021.9.1
+FROM python:3.9-slim
 
 COPY ./LightGBM /opt/LightGBM
+ENV DEBIAN_FRONTEND=noninteractive
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
-ARG DEBIAN_FRONTEND=noninteractive
+
+ARG DASK_VERSION=2021.9.1
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         build-essential \
-        cmake && \
-    rm -rf /var/lib/apt/lists/ && \
-    conda install -y \
-        -c conda-forge \
-        --override-channels \
-            boto3 \
-            dask-cloudprovider \
-            dask-ml \
-            numpy \
-            pandas \
-            scikit-learn && \
+        cmake \
+        libomp-dev && \
+    pip install --no-cache-dir \
+        blosc \
+        bokeh \
+        boto3 \
+        dask==${DASK_VERSION} \
+        dask-cloudprovider \
+        dask-ml \
+        distributed==${DASK_VERSION} \
+        lz4 \
+        numpy==1.21.1 \
+        pandas==1.3.0 \
+        scikit-learn && \
     # install LightGBM
     cd /opt/LightGBM/python-package && \
     python setup.py install && \
     cd /opt && \
     rm -rf /opt/LightGBM && \
-    conda clean --yes --all && \
     apt-get remove -y --purge \
-        build-essential \
-        cmake
+        cmake \
+        build-essential && \
+    rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Contributes to #14.

* switches the base image for `cluster-image` from `daskdev/dask` to `python:3.9-slim`
* adds `libomp-dev` to all images in this project, so LightGBM code can take advantage of OpenMP for mulltithreading
* switches all installs in the `cluster-image` from conda to PyPI

**image sizes**

base: 1.73GB --> 1.73GB
notebook: 1.98GB --> 1.98GB
cluster: 1.67GB --> 1.33GB