### PR TITLE
[ci] update version for CI dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,11 +14,11 @@ jobs:
           - task: linting
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v1
-      - name: Set up Python 3.7
-        uses: s-weigand/setup-conda@v1
+        uses: actions/checkout@v2
+      - name: Set up Python 3.9
+        uses: conda-incubator/setup-miniconda@v2
         with:
-          python-version: 3.7
+          python-version: 3.9
       - name: linting
         if: matrix.task == 'linting'
         shell: bash


### PR DESCRIPTION
It's been more than 9 months since the versions used for some CI dependencies in this project were updated. This PR proposes updating them

* switches to https://github.com/conda-incubator/setup-miniconda for setting up conda
* updates to v2 of https://github.com/actions/checkout (v1 was last updated November 2019)
* upgrades to Python 3.9, to avoid issues when 3.7 goes end-of-life in 2023 ([link](https://endoflife.date/python))