### PR TITLE
change to allowlist pattern in dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,17 +1,5 @@
-# unnecessary LightGBM files
-LightGBM/.appveyor.yml
-LightGBM/build-cran-package.sh
-LightGBM/build_r.R
-LightGBM/.editorconfig
-LightGBM/.github/*
-LightGBM/helpers/*
-LightGBM/.nuget/*
-LightGBM/pmml/*
-LightGBM/R-package/*
-
-# key material
-*.env
-*.pem
-*.pub
-*.rdp
-*_rsa
+*
+!LightGBM/lib_lightgbm.so
+!LightGBM/LICENSE
+!LightGBM/python-package
+!LightGBM/VERSION.txt

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 AWS_REGION=us-east-1
+DASK_VERSION=2021.9.1
 BASE_IMAGE=lightgbm-dask-testing-base:${DASK_VERSION}
 USER_SLUG=$$(echo $${USER} | tr '[:upper:]' '[:lower:]' | tr -cd '[a-zA-Z0-9]-')
 CLUSTER_IMAGE_NAME=lightgbm-dask-testing-cluster-${USER_SLUG}
-DASK_VERSION=2021.9.1
+CLUSTER_IMAGE=${CLUSTER_IMAGE_NAME}:${DASK_VERSION}
 FORCE_REBUILD=0
 NOTEBOOK_IMAGE=lightgbm-dask-testing-notebook:${DASK_VERSION}
 NOTEBOOK_CONTAINER_NAME=dask-lgb-notebook
@@ -22,14 +23,15 @@ base-image:
 
 .PHONY: clean
 clean:
-	git clean -d -f -X
-	rm -rf ./LightGBM/
+	docker rmi $$(docker images -q ${BASE_IMAGE}) || true
+	docker rmi $$(docker images -q ${CLUSTER_IMAGE}) || true
+	docker rmi $$(docker images -q ${NOTEBOOK_IMAGE}) || true
 
 .PHONY: cluster-image
 cluster-image: LightGBM/lib_lightgbm.so
 	docker build \
 		--build-arg DASK_VERSION=${DASK_VERSION} \
-		-t ${CLUSTER_IMAGE_NAME}:${DASK_VERSION} \
+		-t ${CLUSTER_IMAGE} \
 		-f Dockerfile-cluster \
 		.
 


### PR DESCRIPTION
Given the refactoring in #32 , only a small subset of the LightGBM source code needs to actually be used at build time for the images in this repo.

Given this, it's now feasible to switch the `.dockerignore` to an allowlist pattern. This basically means that instead of writing the file like "include everything in the build context, with some exceptions", it now works like "exclude everything from the build context, with some exceptions".

This change reduces the risk of including unnecessary files in the images built from this repo, which should:

* reduce built image size
* reduce build times
* prevent accidental inclusion of sensitive information like AWS keys
