### PR TITLE
add a command for running the Dask unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,17 @@ LightGBM/lib_lightgbm.so: LightGBM/README.md
 		/bin/bash -cex \
 			"mkdir build && cd build && cmake .. && make -j2"
 
+.PHONY: lightgbm-unit-tests
+lightgbm-unit-tests: cluster-image
+	docker run \
+		--rm \
+		-v $$(pwd)/LightGBM:/opt/LightGBM \
+		--workdir=/opt/LightGBM \
+		--entrypoint="" \
+		-it ${CLUSTER_IMAGE} \
+		/bin/bash -cex \
+			"pip install pytest && pytest tests/python_package_test/test_dask.py"
+
 .PHONY: lint
 lint: lint-dockerfiles
 	isort --check .

--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ This repository can be used to test and develop changes to LightGBM's Dask integ
 
 <hr>
 
+**Contents**
+
+- [Getting Started](#getting-started)
+- [Develop in Jupyter](#develop-in-jupyter)
+- [Test with a LocalCluster](#test-with-a-localcluster)
+- [Test with a FargetCluster](#test-with-a-fargetcluster)
+- [Run LightGBM unit tests](#run-lightgbm-unit-tests)
+
 ## Getting Started
 
 To begin, clone a copy of LightGBM to a folder `LightGBM` at the root of this repo. You can do this however you want, for example:
@@ -150,6 +158,21 @@ make delete-repo
 Then, repeat the steps above to rebuild your images and test again.
 
 <hr>
+
+## Run LightGBM unit tests
+
+This repo makes it easy to run `lightgbm`'s Dask unit tests in a containerized setup.
+
+```shell
+make lightgbm-unit-tests
+```
+
+Pass variable `DASK_VERSION` to use a different version of `dask` / `distributed`.
+
+```shell
+make lightgbm-unit-tests \
+    -e DASK_VERSION=2021.11.0
+```
 
 ## Useful Links
 


### PR DESCRIPTION
Proposes adding `make lightgbm-unit-tests`, which makes it easy to run the Dask-specific unit tests in `lightgbm` given:

* a specific version of `dask` / `distributed`
* the current state of `lightgbm` in local folder `./LightGBM`

I'm hoping this will be useful for developing on `lightgbm.dask`. It's especially useful for me because my main development machine is a mac, and as of this writing the `lightgbm.dask` unit tests aren't run on mac.

https://github.com/microsoft/LightGBM/blob/aa647d478fd12d8c96eebc2ccc6003e8bacae322/tests/python_package_test/test_dask.py#L18-L19