### PR TITLE
consolidate hardcoded AWS region

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-AWS_REGION=us-east-1
+AWS_REGION=us-west-2
 DASK_VERSION=2021.9.1
 USER_SLUG=$$(echo $${USER} | tr '[:upper:]' '[:lower:]' | tr -cd '[a-zA-Z0-9]-')
 CLUSTER_BASE_IMAGE=lightgbm-dask-testing-cluster-base:${DASK_VERSION}
@@ -43,17 +43,17 @@ create-repo: ecr-details.json
 
 .PHONY: delete-repo
 delete-repo:
-	aws --region us-east-1 \
+	aws --region ${AWS_REGION} \
 		ecr-public batch-delete-image \
 			--repository-name ${CLUSTER_IMAGE_NAME} \
 			--image-ids imageTag=${DASK_VERSION}
-	aws --region us-east-1 \
+	aws --region ${AWS_REGION} \
 		ecr-public delete-repository \
 			--repository-name ${CLUSTER_IMAGE_NAME}
 	rm -f ./ecr-details.json
 
 ecr-details.json:
-	aws --region us-east-1 \
+	aws --region ${AWS_REGION} \
 		ecr-public create-repository \
 			--repository-name ${CLUSTER_IMAGE_NAME} \
 	> ./ecr-details.json
@@ -155,7 +155,7 @@ start-notebook:
 		--rm \
 		-v $$(pwd):/home/jovyan/testing \
 		--env AWS_ACCESS_KEY_ID=$${AWS_ACCESS_KEY_ID:-notset} \
-		--env AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION} \
+		--env AWS_DEFAULT_REGION=${AWS_REGION} \
 		--env AWS_SECRET_ACCESS_KEY=$${AWS_SECRET_ACCESS_KEY:-notset} \
 		-p 8888:8888 \
 		-p 8787:8787 \

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ pip install --upgrade awscli
 
 Next, configure your shell to make authenticated requests to AWS. If you've never done this, you can see [the AWS CLI docs](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html).
 
-The rest of this section assums that the shell variables `AWS_SECRET_ACCESS_KEY`, `AWS_ACCESS_KEY_ID`, and `AWS_DEFAULT_REGION` have been set.
+The rest of this section assums that the shell variables `AWS_SECRET_ACCESS_KEY` and `AWS_ACCESS_KEY_ID` have been sett.
 
 I like to set these by keeping them in a file
 
@@ -116,7 +116,6 @@ I like to set these by keeping them in a file
 # file: aws.env
 AWS_SECRET_ACCESS_KEY=your-key-here
 AWS_ACCESS_KEY_ID=your-access-key-id-here
-AWS_DEFAULT_REGION=us-east-1
 ```
 
 and then sourcing that file

--- a/notebooks/demo-aws.ipynb
+++ b/notebooks/demo-aws.ipynb
@@ -63,18 +63,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "sufficient-evanescence",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "\n",
-    "os.environ[\"AWS_DEFAULT_REGION\"] = \"us-west-2\""
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "complicated-little",
    "metadata": {},


### PR DESCRIPTION
There are several hardcoded referenced to AWS region in this project. That introduces the risk of inconsistency and prevents customizing region with something like `make -e AWS_REGION=us-west-2`.

This PR fixes that.