### PR TITLE
fix typo in INSTALL_DIR

### DIFF
--- a/Dockerfile-cluster
+++ b/Dockerfile-cluster
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE
-ARG INSTALL_DIR=/opt/LightGBMM
+ARG INSTALL_DIR=/opt/LightGBM
 
 # hadolint ignore=DL3006
 FROM ${BASE_IMAGE}

--- a/Makefile
+++ b/Makefile
@@ -64,8 +64,8 @@ ecr-details.json:
 format:
 	black .
 	isort .
-	nbqa isort . --nbqa-mutate
-	nbqa black . --nbqa-mutate
+	nbqa isort .
+	nbqa black .
 
 LightGBM/README.md:
 	git clone --recursive https://github.com/microsoft/LightGBM.git
@@ -95,12 +95,8 @@ lightgbm-unit-tests: cluster-image
 lint: lint-dockerfiles
 	isort --check .
 	black --check --diff .
-	diff_lines=$$(nbqa black --nbqa-diff . | wc -l); \
-	if [ $${diff_lines} -gt 0 ]; then \
-		echo "Some notebooks would be reformatted by black. Run 'make format' and try again."; \
-		exit 1; \
-	fi
 	flake8 --count .
+	nbqa black --check --diff .
 	nbqa flake8 .
 	nbqa isort --check .
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,4 +13,3 @@ ignore =
 
 [tool:isort]
 skip_glob=*/LightGBM/*
-


### PR DESCRIPTION
Fixed a misspelled path (`LIGHTGBMM -> LightGBM`).

While doing that, I found that CI jobs were failing. Pushed some changes to fix that.

* removes deprecated `--nbqa-mutate` argument
   - resolved warning:
   - > Flag --nbqa-mutate was deprecated in 1.0.0 and is now unnecessary
* removes trailing blank line in `setup.cfg`
* simplifies `nbqa black`...weird workaround with `if` is no longer necessary