### PR TITLE
Add runtime profiling of LightGBM python examples

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 *
+!bin/profile-examples.sh
 !LightGBM/lib_lightgbm.so
 !LightGBM/LICENSE
 !LightGBM/python-package

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ LightGBM/
 *.ppt
 *.pptm
 *.pptx
+profiling-output/
 *.pq
 *.pyc
 __pycache/

--- a/Dockerfile-profiling
+++ b/Dockerfile-profiling
@@ -1,0 +1,12 @@
+ARG BASE_IMAGE
+
+# hadolint ignore=DL3006
+FROM ${BASE_IMAGE}
+
+RUN pip install --no-cache-dir \
+        memray \
+        pytest \
+        pytest-profiling \
+        snakeviz
+
+COPY bin/profile-examples.sh /usr/local/bin/profile-examples.sh

--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ profile: profiling-image
 		--entrypoint="" \
 		-it ${PROFILING_IMAGE} \
 		/bin/bash -cex \
-			'/bin/bash /usr/local/bin/profile-examples.sh && python -m snakeviz ${PROFILING_OUTPUT_DIR}/ --hostname 0.0.0.0 --server'
+			'/bin/bash /usr/local/bin/profile-examples.sh && python -m snakeviz /profiling-output/ --hostname 0.0.0.0 --server'
 
 .PHONY: profiling-image
 profiling-image: cluster-image

--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,7 @@ notebook-image: notebook-base-image LightGBM/lib_lightgbm.so
 profile: profiling-image
 	docker run \
 		--rm \
+		-p 8080:8080 \
 		--env LIGHTGBM_HOME=/opt/LightGBM \
 		--env PROFILING_OUTPUT_DIR=/profiling-output \
 		-v $$(pwd)/profiling-output:/profiling-output \

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,11 @@ CLUSTER_BASE_IMAGE=lightgbm-dask-testing-cluster-base:${DASK_VERSION}
 CLUSTER_IMAGE_NAME=lightgbm-dask-testing-cluster-${USER_SLUG}
 CLUSTER_IMAGE=${CLUSTER_IMAGE_NAME}:${DASK_VERSION}
 FORCE_REBUILD=0
+FORCE_REBUILD_PROFILING_IMAGE=0
 NOTEBOOK_BASE_IMAGE=lightgbm-dask-testing-notebook-base:${DASK_VERSION}
 NOTEBOOK_IMAGE=lightgbm-dask-testing-notebook:${DASK_VERSION}
 NOTEBOOK_CONTAINER_NAME=dask-lgb-notebook
+PROFILING_IMAGE=lightgbm-dask-testing-profiling:${DASK_VERSION}
 
 .PHONY: clean
 clean:
@@ -17,6 +19,7 @@ clean:
 	docker rmi $$(docker images -q ${CLUSTER_BASE_IMAGE}) || true
 	docker rmi $$(docker images -q ${NOTEBOOK_IMAGE}) || true
 	docker rmi $$(docker images -q ${NOTEBOOK_BASE_IMAGE}) || true
+	docker rmi $$(docker images -q ${PROFILING_IMAGE}) || true
 
 .PHONY: cluster-base-image
 cluster-base-image:
@@ -131,6 +134,34 @@ notebook-image: notebook-base-image LightGBM/lib_lightgbm.so
 		-t ${NOTEBOOK_IMAGE} \
 		-f Dockerfile-notebook \
 		--build-arg BASE_IMAGE=${NOTEBOOK_BASE_IMAGE} \
+		.
+
+.PHONY: profile
+profile: profiling-image
+	docker run \
+		--rm \
+		--env LIGHTGBM_HOME=/opt/LightGBM \
+		--env PROFILING_OUTPUT_DIR=/profiling-output \
+		-v $$(pwd)/profiling-output:/profiling-output \
+		-v $$(pwd)/LightGBM:/opt/LightGBM \
+		--workdir=/opt/LightGBM \
+		--entrypoint="" \
+		-it ${PROFILING_IMAGE} \
+		/bin/bash -cex \
+			'/bin/bash /usr/local/bin/profile-examples.sh && python -m snakeviz ${PROFILING_OUTPUT_DIR}/ --hostname 0.0.0.0 --server'
+
+.PHONY: profiling-image
+profiling-image: cluster-image
+	@if $$(docker image inspect ${PROFILING_IMAGE} > /dev/null); then \
+		if test ${FORCE_REBUILD_PROFILING_IMAGE} -le 0; then \
+			echo "image '${PROFILING_IMAGE}' already exists. To force rebuilding, run 'make profiling-image -e FORCE_REBUILD_PROFILING_IMAGE=1'."; \
+			exit 0; \
+		fi; \
+	fi;
+	docker build \
+		-t ${PROFILING_IMAGE} \
+		--build-arg BASE_IMAGE=${CLUSTER_IMAGE} \
+		-f Dockerfile-profiling \
 		.
 
 # https://docs.amazonaws.cn/en_us/AmazonECR/latest/public/docker-push-ecr-image.html

--- a/bin/profile-examples.sh
+++ b/bin/profile-examples.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# [description]
+#
+#     Profile all of LightGBM's Python examples, using cProfile.
+
+set -e -u -o pipefail
+
+echo "profiling examples"
+for py_script in $(find "${LIGHTGBM_HOME}/examples/python-guide" -name '*.py'); do
+    base_filename=$(basename "${py_script}")
+    prof_file=$(echo "${base_filename}" | sed -e 's/\.py/\.prof/g')
+    echo "  - ${base_filename}"
+    python \
+        -Wignore \
+        -m cProfile \
+        -o "${PROFILING_OUTPUT_DIR}/${prof_file}" \
+        "${py_script}" 2>&1 > /dev/null \
+    || true
+done
+echo "Done profiling examples. See '${PROFILING_OUTPUT_DIR}' for results."


### PR DESCRIPTION
Contributes to #44.

Adds a setup, using `cProfile` and `snakeviz`, to look for where LightGBM's python examples are spending the most time.

<img width="1766" alt="image" src="https://user-images.githubusercontent.com/7608904/165620083-e0c6ddaf-7403-455b-aa7e-721ad4700b30.png">

<img width="1345" alt="image" src="https://user-images.githubusercontent.com/7608904/165620316-8b3691ea-8b67-4d4d-b0ec-5bbd85f7aa6d.png">
