### PR TITLE
allow building cluster image directly (fixes #52)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,10 +72,10 @@ format:
 	nbqa isort .
 	nbqa black .
 
-LightGBM/README.md:
+"LightGBM/README.md":
 	git clone --recursive https://github.com/microsoft/LightGBM.git
 
-LightGBM/lib_lightgbm.so: LightGBM/README.md
+"LightGBM/lib_lightgbm.so": LightGBM/README.md notebook-base-image
 	docker run \
 		--rm \
 		-v $$(pwd)/LightGBM:/opt/LightGBM \


### PR DESCRIPTION
Fixes #52.

Making `notebook-base-image` a dependency of `LightGBM/lib_lightgbm.so` was enough to resolve the error message noted in #52.

Running the following now works successfully!

```shell
make clean lightgbm-unit-tests
```

The changes to quoting for the `"LightGBM/*"` targets is because without it, successive runs of `make lightgbm-unit-tests` resulted in the following (at least on my Mac).

```text
mkdir: cannot create directory ‘build’: File exists
make: *** [LightGBM/lib_lightgbm.so] Error 1
```