### PR TITLE
remove token auth in notebook

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 *
 !bin/profile-examples.sh
+!jupyter_notebook_config.py
 !LightGBM/lib_lightgbm.so
 !LightGBM/LICENSE
 !LightGBM/python-package

--- a/Dockerfile-notebook
+++ b/Dockerfile-notebook
@@ -4,6 +4,7 @@ ARG INSTALL_DIR=/root/testing/LightGBM
 # hadolint ignore=DL3006
 FROM ${BASE_IMAGE}
 
+COPY jupyter_notebook_config.py /root/.jupyter/jupyter_notebook_config.py
 COPY LightGBM/lib_lightgbm.so ${INSTALL_DIR}/lib_lightgbm.so
 COPY LightGBM/LICENSE ${INSTALL_DIR}/LICENSE
 COPY LightGBM/python-package ${INSTALL_DIR}/python-package

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ NOTEBOOK_IMAGE=lightgbm-dask-testing-notebook:${DASK_VERSION}
 NOTEBOOK_CONTAINER_NAME=dask-lgb-notebook
 PROFILING_IMAGE=lightgbm-dask-testing-profiling:${DASK_VERSION}
 
+LIB_LIGHTGBM=${PWD}/LightGBM/lib_lightgbm.so
+LIGHTGBM_REPO=${PWD}/LightGBM/README.md
+
 .PHONY: clean
 clean:
 	docker rmi $$(docker images -q ${CLUSTER_IMAGE}) || true
@@ -37,7 +40,7 @@ cluster-base-image:
 		- < Dockerfile-cluster-base
 
 .PHONY: cluster-image
-cluster-image: cluster-base-image "LightGBM/lib_lightgbm.so"
+cluster-image: cluster-base-image $(LIB_LIGHTGBM)
 	docker build \
 		--build-arg DASK_VERSION=${DASK_VERSION} \
 		-t ${CLUSTER_IMAGE} \
@@ -72,10 +75,10 @@ format:
 	nbqa isort .
 	nbqa black .
 
-"LightGBM/README.md":
+$(LIGHTGBM_REPO):
 	git clone --recursive https://github.com/microsoft/LightGBM.git
 
-"LightGBM/lib_lightgbm.so": LightGBM/README.md
+$(LIB_LIGHTGBM): $(LIGHTGBM_REPO)
 	make notebook-base-image
 	docker run \
 		--rm \
@@ -132,7 +135,7 @@ notebook-base-image:
 		- < Dockerfile-notebook-base
 
 .PHONY: notebook-image
-notebook-image: notebook-base-image "LightGBM/lib_lightgbm.so"
+notebook-image: notebook-base-image $(LIB_LIGHTGBM)
 	docker build \
 		-t ${NOTEBOOK_IMAGE} \
 		-f Dockerfile-notebook \

--- a/README.md
+++ b/README.md
@@ -51,26 +51,18 @@ Every time after that, `make notebook-image` should run very quickly.
 
 #### 2. Run a notebook locally
 
-Start up Jupyter Lab! This command will run Jupyter Lab in a container using the image you built with `make notebook-image`.
+Start up Jupyter Lab!
+This command will run Jupyter Lab in a container using the image you built with `make notebook-image`.
 
 ```shell
 make start-notebook
 ```
 
-After running this command, you'll see some output like this:
+Navigate to `http://127.0.0.1:8888/lab` in your web browser.
 
-```text
-[C 23:03:44.234 LabApp]
-    To access the notebook, open this file in a browser:
-        file:///home/jovyan/.local/share/jupyter/runtime/nbserver-19-open.html
-    Or copy and paste one of these URLs:
-        http://d96d64837199:8888/?token=e8aa897c8afbbbc559976854a78cc9effe957a912270f7bf
-     or http://127.0.0.1:8888/?token=e8aa897c8afbbbc559976854a78cc9effe957a912270f7bf
-```
-
-Copy the URL starting with `http://127.0.0.1` and paste it into your web browser. This will open Jupyter Lab.
-
-The command `make start-notebook` mounts your current working directory into the running container. That means that even though Jupyter Lab is running inside the container, changes that you make in it will be saved on your local filesystem even after you shut the container down. So you can edit and create notebooks and other code in there with confidence!
+The command `make start-notebook` mounts your current working directory into the running container.
+That means that even though Jupyter Lab is running inside the container, changes that you make in it will be saved on your local filesystem even after you shut the container down.
+So you can edit and create notebooks and other code in there with confidence!
 
 When you're done with the notebook, stop the container by running the following from another shell:
 

--- a/jupyter_notebook_config.py
+++ b/jupyter_notebook_config.py
@@ -1,0 +1,4 @@
+c.ServerApp.token = ""
+c.ServerApp.password = ""
+c.ServerApp.open_browser = False
+c.ServerApp.ip = "localhost"

--- a/jupyter_notebook_config.py
+++ b/jupyter_notebook_config.py
@@ -1,3 +1,4 @@
+# noqa
 c.ServerApp.token = ""
 c.ServerApp.password = ""
 c.ServerApp.open_browser = False

--- a/jupyter_notebook_config.py
+++ b/jupyter_notebook_config.py
@@ -1,4 +1,3 @@
-# noqa
 c.ServerApp.token = ""
 c.ServerApp.password = ""
 c.ServerApp.open_browser = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [flake8]
-exclude = LightGBM
+exclude = jupyter_notebook_config.py,LightGBM
 max-line-length = 100
 ignore =
     # module level import not at top of file


### PR DESCRIPTION
Having Jupyter Lab generate a new random token every time you run `make start-notebook` isn't really adding any security benefit...this project is just intended to be run in your local dev environment, while working on LightGBM.

This PR removes that auth, and therefore one manual step in getting up and running.