### PR TITLE
upgrade Dask and Python versions

### DIFF
--- a/Dockerfile-cluster-base
+++ b/Dockerfile-cluster-base
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.11-slim
 
 ENV \
     DEBIAN_FRONTEND=noninteractive \
@@ -12,7 +12,7 @@ RUN apt-get update && \
         build-essential \
         cmake \
         libomp-dev && \
-    pip install --no-cache-dir \
+    pip install --prefer-binary --no-cache-dir \
         blosc \
         bokeh \
         dask==${DASK_VERSION} \
@@ -20,11 +20,11 @@ RUN apt-get update && \
         distributed==${DASK_VERSION} \
         lz4 \
         numpy \
-        pandas \
+        'pandas>=2.0.0' \
         scikit-learn && \
     # remove unnecessary file
     find \
-        /usr/local/lib/python3.9/site-packages \
+        /usr/local/lib/python3.11/site-packages \
         -type f \
         \( \
         -name '*.c' \
@@ -47,7 +47,7 @@ RUN apt-get update && \
         \) \
         -exec rm '{}' '+' && \
     find \
-        /usr/local/lib/python3.9/site-packages \
+        /usr/local/lib/python3.11/site-packages \
         -type d \
         -wholename '*__pycache__*' \
         -exec rm -rf '{}' '+' && \

--- a/Dockerfile-notebook-base
+++ b/Dockerfile-notebook-base
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.11-slim
 
 ARG DASK_VERSION
 
@@ -25,11 +25,11 @@ RUN apt-get update && \
         jupyterlab \
         lz4 \
         numpy \
-        pandas \
+        'pandas>=2.0.0' \
         scikit-learn && \
     # remove unnecessary file
     find \
-        /usr/local/lib/python3.9/site-packages \
+        /usr/local/lib/python3.11/site-packages \
         -type f \
         \( \
         -name '*.c' \
@@ -52,7 +52,7 @@ RUN apt-get update && \
         \) \
         -exec rm '{}' '+' && \
     find \
-        /usr/local/lib/python3.9/site-packages \
+        /usr/local/lib/python3.11/site-packages \
         -type d \
         -wholename '*__pycache__*' \
         -exec rm -rf '{}' '+' && \

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # NOTE: using us-east-1 because it is the only region that supports
 #       ECR BatchDeleteImage()
 AWS_REGION=us-east-1
-DASK_VERSION=2022.11.1
+DASK_VERSION=2023.5.0
 USER_SLUG=$$(echo $${USER} | tr '[:upper:]' '[:lower:]' | tr -cd '[a-zA-Z0-9]-')
 CLUSTER_BASE_IMAGE=lightgbm-dask-testing-cluster-base:${DASK_VERSION}
 CLUSTER_IMAGE_NAME=lightgbm-dask-testing-cluster-${USER_SLUG}

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Pass variable `DASK_VERSION` to use a different version of `dask` / `distributed
 
 ```shell
 make lightgbm-unit-tests \
-    -e DASK_VERSION=2021.11.0
+    -e DASK_VERSION=2023.4.0
 ```
 
 ## Profile LightGBM code <a name="profiling"></a>

--- a/notebooks/demo.ipynb
+++ b/notebooks/demo.ipynb
@@ -249,7 +249,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.14"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Contributes to testing https://github.com/microsoft/LightGBM/pull/5890.

* upgrades default Python to 3.11
* upgrades default `dask` and `distributed` to `2023.5.0`
* ensures that images always use Python `2.0+`
