### PR TITLE
build profiling image in CI, add arm64 support to AWS notebooks

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,5 +13,4 @@
 !LightGBM/python-package
 !LightGBM/src
 !LightGBM/swig
-!LightGBM/windows
 !LightGBM/VERSION.txt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Build cluster image
         run: |
           make cluster-image
+      - name: Build profiling image
+        run: |
+          make profiling-image
   all-tests-successful:
     if: always()
     runs-on: ubuntu-latest

--- a/Dockerfile-cluster
+++ b/Dockerfile-cluster
@@ -3,7 +3,7 @@ ARG BASE_IMAGE=unset
 # hadolint ignore=DL3006
 FROM ${BASE_IMAGE}
 
-RUN --mount=type=bind,source=LightGBM,target=/tmp/LightGBM \
+RUN --mount=type=bind,source=LightGBM,target=/tmp/LightGBM,rw \
 <<EOF
 cd /tmp/LightGBM
 

--- a/Dockerfile-notebook
+++ b/Dockerfile-notebook
@@ -5,7 +5,7 @@ FROM ${BASE_IMAGE}
 
 COPY jupyter_notebook_config.py /root/.jupyter/jupyter_notebook_config.py
 
-RUN --mount=type=bind,source=LightGBM,target=/tmp/LightGBM \
+RUN --mount=type=bind,source=LightGBM,target=/tmp/LightGBM,rw \
 <<EOF
 cd /tmp/LightGBM
 

--- a/Dockerfile-profiling
+++ b/Dockerfile-profiling
@@ -3,12 +3,14 @@ ARG BASE_IMAGE=unset
 # hadolint ignore=DL3006
 FROM ${BASE_IMAGE}
 
-RUN pip install --no-cache-dir --prefer-binary \
-        memray \
-        pytest \
-        pytest-memray \
-        pytest-profiling \
-        snakeviz
+RUN <<<EOF
+pip install --no-cache-dir --prefer-binary \
+    memray \
+    pytest \
+    pytest-memray \
+    pytest-profiling \
+    snakeviz
+EOF
 
 COPY bin/profile-examples.sh /usr/local/bin/profile-examples.sh
 COPY bin/profile-example-memory-usage.sh /usr/local/bin/profile-example-memory-usage.sh

--- a/Dockerfile-profiling
+++ b/Dockerfile-profiling
@@ -3,7 +3,7 @@ ARG BASE_IMAGE=unset
 # hadolint ignore=DL3006
 FROM ${BASE_IMAGE}
 
-RUN <<<EOF
+RUN <<EOF
 pip install --no-cache-dir --prefer-binary \
     memray \
     pytest \

--- a/Makefile
+++ b/Makefile
@@ -200,6 +200,8 @@ push-image: create-repo
 	docker push \
 		$$(cat ./ecr-details.json | jq .'repository'.'repositoryUri' | tr -d '"'):${IMAGE_TAG}
 
+# NOTE: IMAGE_TAG is in the environment here so the AWS notebooks
+#       know what image to use for the Dask cluster
 .PHONY: start-notebook
 start-notebook:
 	docker run \
@@ -208,6 +210,7 @@ start-notebook:
 		--env AWS_ACCESS_KEY_ID=$${AWS_ACCESS_KEY_ID:-notset} \
 		--env AWS_DEFAULT_REGION=${AWS_REGION} \
 		--env AWS_SECRET_ACCESS_KEY=$${AWS_SECRET_ACCESS_KEY:-notset} \
+		--env IMAGE_TAG=${IMAGE_TAG} \
 		-p 8888:8888 \
 		-p 8787:8787 \
 		--name ${NOTEBOOK_CONTAINER_NAME} \

--- a/notebooks/demo-aws.ipynb
+++ b/notebooks/demo-aws.ipynb
@@ -40,18 +40,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "expanded-declaration",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "scheduler and worker image: public.ecr.aws/w8s1c8b1/lightgbm-dask-testing-cluster-jlamb:py3.12-dask2024.6.2\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import json\n",
     "import os\n",
@@ -79,16 +71,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "4a10d61c-5251-46a7-9f16-bd6eef606a82",
    "metadata": {},
    "outputs": [],
    "source": [
     "import platform\n",
+    "\n",
     "if platform.machine().lower() in {\"aarch64\", \"arm64\"}:\n",
-    "    cpu_architecture=\"ARM64\"\n",
+    "    cpu_architecture = \"ARM64\"\n",
     "else:\n",
-    "    cpu_architecture=\"X86_64\""
+    "    cpu_architecture = \"X86_64\""
    ]
   },
   {
@@ -104,16 +97,7 @@
    "execution_count": null,
    "id": "respective-collect",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/usr/local/lib/python3.12/contextlib.py:144: UserWarning: Creating your cluster is taking a surprisingly long time. This is likely due to pending resources on AWS. Hang tight! \n",
-      "  next(self.gen)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from dask.distributed import Client\n",
     "from dask_cloudprovider.aws import FargateCluster\n",
@@ -134,18 +118,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "raising-mauritius",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "View the dashboard: http://52.55.229.38:8787/status\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(f\"View the dashboard: {cluster.dashboard_link}\")"
    ]
@@ -174,7 +150,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "structural-street",
    "metadata": {},
    "outputs": [],
@@ -199,7 +175,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "quiet-nicaragua",
    "metadata": {},
    "outputs": [],
@@ -225,22 +201,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "pleased-brunei",
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "ModuleNotFoundError",
-     "evalue": "No module named 'lightgbm'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[13], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mlightgbm\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mdask\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m DaskLGBMRegressor\n\u001b[1;32m      3\u001b[0m dask_reg \u001b[38;5;241m=\u001b[39m DaskLGBMRegressor(\n\u001b[1;32m      4\u001b[0m     client\u001b[38;5;241m=\u001b[39mclient,\n\u001b[1;32m      5\u001b[0m     max_depth\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m5\u001b[39m,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m     10\u001b[0m     min_child_samples\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m1\u001b[39m,\n\u001b[1;32m     11\u001b[0m )\n\u001b[1;32m     13\u001b[0m dask_reg\u001b[38;5;241m.\u001b[39mfit(\n\u001b[1;32m     14\u001b[0m     X\u001b[38;5;241m=\u001b[39mdX,\n\u001b[1;32m     15\u001b[0m     y\u001b[38;5;241m=\u001b[39mdy,\n\u001b[1;32m     16\u001b[0m )\n",
-      "\u001b[0;31mModuleNotFoundError\u001b[0m: No module named 'lightgbm'"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from lightgbm.dask import DaskLGBMRegressor\n",
     "\n",

--- a/notebooks/demo-aws.ipynb
+++ b/notebooks/demo-aws.ipynb
@@ -40,10 +40,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "expanded-declaration",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "scheduler and worker image: public.ecr.aws/w8s1c8b1/lightgbm-dask-testing-cluster-jlamb:py3.12-dask2024.6.2\n"
+     ]
+    }
+   ],
    "source": [
     "import json\n",
     "import os\n",
@@ -51,10 +59,10 @@
     "with open(\"../ecr-details.json\", \"r\") as f:\n",
     "    ecr_details = json.loads(f.read())\n",
     "\n",
-    "CONTAINER_IMAGE = (\n",
-    "    ecr_details[\"repository\"][\"repositoryUri\"] + \":\" + os.environ[\"DASK_VERSION\"]\n",
-    ")\n",
-    "print(f\"scheduler and worker image: {CONTAINER_IMAGE}\")"
+    "IMAGE_REPO = ecr_details[\"repository\"][\"repositoryUri\"]\n",
+    "IMAGE_TAG = os.environ[\"IMAGE_TAG\"]\n",
+    "IMAGE_URI = f\"{IMAGE_REPO}:{IMAGE_TAG}\"\n",
+    "print(f\"scheduler and worker image: {IMAGE_URI}\")"
    ]
   },
   {
@@ -62,7 +70,25 @@
    "id": "harmful-bosnia",
    "metadata": {},
    "source": [
-    "Before proceeding, set up your AWS credentials. If you're unsure how to do this, see [the AWS docs](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html)."
+    "Before proceeding, set up your AWS credentials. If you're unsure how to do this, see [the AWS docs](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html).\n",
+    "\n",
+    "Next, determine the CPU architecture of the machine you're running on.\n",
+    "This project builds single-architecture container images matching the host system, so it's important\n",
+    "to use the same CPU architecture on AWS Fargate."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "4a10d61c-5251-46a7-9f16-bd6eef606a82",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import platform\n",
+    "if platform.machine().lower() in {\"aarch64\", \"arm64\"}:\n",
+    "    cpu_architecture=\"ARM64\"\n",
+    "else:\n",
+    "    cpu_architecture=\"X86_64\""
    ]
   },
   {
@@ -78,14 +104,24 @@
    "execution_count": null,
    "id": "respective-collect",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/lib/python3.12/contextlib.py:144: UserWarning: Creating your cluster is taking a surprisingly long time. This is likely due to pending resources on AWS. Hang tight! \n",
+      "  next(self.gen)\n"
+     ]
+    }
+   ],
    "source": [
     "from dask.distributed import Client\n",
     "from dask_cloudprovider.aws import FargateCluster\n",
     "\n",
     "n_workers = 3\n",
     "cluster = FargateCluster(\n",
-    "    image=CONTAINER_IMAGE,\n",
+    "    image=IMAGE_URI,\n",
+    "    cpu_architecture=cpu_architecture,\n",
     "    worker_cpu=512,\n",
     "    worker_mem=4096,\n",
     "    n_workers=n_workers,\n",
@@ -98,10 +134,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "raising-mauritius",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "View the dashboard: http://52.55.229.38:8787/status\n"
+     ]
+    }
+   ],
    "source": [
     "print(f\"View the dashboard: {cluster.dashboard_link}\")"
    ]
@@ -130,7 +174,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "structural-street",
    "metadata": {},
    "outputs": [],
@@ -155,7 +199,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "quiet-nicaragua",
    "metadata": {},
    "outputs": [],
@@ -181,10 +225,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "id": "pleased-brunei",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "ModuleNotFoundError",
+     "evalue": "No module named 'lightgbm'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[13], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mlightgbm\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mdask\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m DaskLGBMRegressor\n\u001b[1;32m      3\u001b[0m dask_reg \u001b[38;5;241m=\u001b[39m DaskLGBMRegressor(\n\u001b[1;32m      4\u001b[0m     client\u001b[38;5;241m=\u001b[39mclient,\n\u001b[1;32m      5\u001b[0m     max_depth\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m5\u001b[39m,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m     10\u001b[0m     min_child_samples\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m1\u001b[39m,\n\u001b[1;32m     11\u001b[0m )\n\u001b[1;32m     13\u001b[0m dask_reg\u001b[38;5;241m.\u001b[39mfit(\n\u001b[1;32m     14\u001b[0m     X\u001b[38;5;241m=\u001b[39mdX,\n\u001b[1;32m     15\u001b[0m     y\u001b[38;5;241m=\u001b[39mdy,\n\u001b[1;32m     16\u001b[0m )\n",
+      "\u001b[0;31mModuleNotFoundError\u001b[0m: No module named 'lightgbm'"
+     ]
+    }
+   ],
    "source": [
     "from lightgbm.dask import DaskLGBMRegressor\n",
     "\n",
@@ -300,7 +356,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.12.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
More miscellaneous refactoring.

* omits the `windows/` directory from LightGBM (no longer necessary to build the package, as of https://github.com/microsoft/LightGBM/pull/6698)
* adds profiling image to CI
* explicitly sets CPU architecture in `dask_cloudprovider.FargateCluster` example, to fix this:
* mounts in `LightGBM/` as read-write at build time

## Notes for Reviewers

### Why set CPU architecture?

This repo only builds single-architecture container images.
The notebooks are intended to be run locally, from the same machine where you built all the images.

`dask_cloudprovider.FargateCluster` defaults to x86_64.
When I built the images on my M2 Mac (which is arm64) then tried to run the `demo-aws` notebook as-is, I saw this error on ECS:

> exec /usr/local/bin/dask-scheduler: exec format error

This fixes that by detecting CPU architecture on the machine where the notebook is running, and passing that through. Thanks to @dmitry-livchak for adding that support in https://github.com/dask/dask-cloudprovider/pull/425 😁 

### Why make `LightGBM/` read-write at build time?

Without it, the build fails like this:

> cp: cannot create directory './lightgbm-python': Read-only file system

Because `build-python.sh` from LightGBM creates a temporary directory and moves files into it ([code link](https://github.com/microsoft/LightGBM/blob/60b0155ac573a8ad5994c74c49e05854281e2469/build-python.sh#L216)).