### PR TITLE
add a PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+## Description
+
+## Benefits of this work
+
+## Notes for Reviewers
+
+### How I tested this


### PR DESCRIPTION
fixes #17

Adds a PR template, following the docs at https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository